### PR TITLE
Add local broker for a local factor app

### DIFF
--- a/cmd/heroku.go
+++ b/cmd/heroku.go
@@ -2,13 +2,10 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 
 	heroku "github.com/heroku/heroku-go/v5"
 
@@ -32,186 +29,31 @@ var teamName string
 var discover bool
 
 func init() {
+	herokuCmd.Flags().StringVar(&teamName, "team", "", "limit apps to this team")
+	herokuCmd.Flags().BoolVar(&discover, "discover", false, "discover issuer and sub")
+	cmd.AddCommand(herokuCmd)
+}
+
+func getResourceHeroku(name string, url string, discover bool, updater configUpdater) *Resource {
+	iss := url  // the local factor identity provider uses the app url
+	sub := name // the local factor identity provider uses the app name
+	if discover {
+		// TODO: use local run:insade to call `factor issuer` and parse output
+	}
+	return getResource(name, url, iss, sub, updater)
+}
+
+func runHeroku() error {
 	token, ok := os.LookupEnv("HEROKU_API_KEY")
 	if !ok {
 		log.Fatal("HEROKU_API_KEY not set")
 	}
-	herokuCmd.Flags().StringVar(&teamName, "team", "", "limit apps to this team")
-	herokuCmd.Flags().BoolVar(&discover, "discover", false, "discover issuer and sub")
-	cmd.AddCommand(herokuCmd)
 	httpClient := &http.Client{
 		Transport: &heroku.Transport{
 			BearerToken: token,
 		},
 	}
 	client = heroku.NewService(httpClient)
-}
-
-func toConfig(data json.RawMessage, prefix string, config map[string]*string) error {
-	if isJSONEmpty(data) {
-		return nil
-	}
-	rawMap := map[string]interface{}{}
-	err := json.Unmarshal(data, &rawMap)
-	if err != nil {
-		return fmt.Errorf("error unmarshaling JSON: %w", err)
-	}
-
-	for key, value := range rawMap {
-		strValue := fmt.Sprintf("%v", value)
-		config[strings.ToUpper(fmt.Sprintf("%s%s", prefix, key))] = &strValue
-	}
-	return nil
-}
-
-type IdentityValidator struct {
-	Iss string `json:"iss,omitempty"`
-	Sub string `json:"sub,omitempty"`
-	Aud string `json:"aud,omitempty"`
-}
-
-type IncomingIdentity map[string]IdentityValidator
-
-func toIncomingIdentity(pipe *Pipe, config map[string]*string) error {
-	if isJSONEmpty(pipe.Other.Data) {
-		return nil
-	}
-	rawMap := map[string]interface{}{}
-	err := json.Unmarshal(pipe.Other.Data, &rawMap)
-	if err != nil {
-		return fmt.Errorf("error unmarshaling JSON: %w", err)
-	}
-	// TODO explicitly check that we are the provider of an OIDCAuth adapter
-	if _, ok := rawMap["ISS"]; ok {
-		iss, ok := rawMap["ISS"].(string)
-		if !ok {
-			return fmt.Errorf("field 'ISS' is missing or not a string")
-		}
-		sub, ok := rawMap["SUB"].(string)
-		if !ok {
-			return fmt.Errorf("field 'sub' is missing or not a string")
-		}
-		aud, ok := rawMap["AUD"].(string)
-		if !ok {
-			return fmt.Errorf("field 'aud' is missing or not a string")
-		}
-		incoming := IncomingIdentity{}
-		incoming[pipe.ID] = IdentityValidator{
-			Iss: iss,
-			Sub: sub,
-			Aud: aud,
-		}
-		incomingJson, err := json.Marshal(&incoming)
-		if err != nil {
-			return fmt.Errorf("error marshaling JSON: %w", err)
-		}
-		incomingStr := string(incomingJson)
-		config["INCOMING_IDENTITY"] = &incomingStr
-	}
-	// TODO explicitly check that we are the consumer of an OIDCAuth adapter
-	if _, ok := rawMap["URI"]; ok {
-		// set a config var to create an identity token
-		thisMap := map[string]interface{}{}
-		err := json.Unmarshal(pipe.This.Data, &thisMap)
-		if err != nil {
-			return fmt.Errorf("error unmarshaling JSON: %w", err)
-		}
-		if aud, ok := thisMap["AUD"].(string); ok {
-			config[strings.ToUpper(fmt.Sprintf("%s_AUDIENCE", pipe.ID))] = &aud
-		}
-	}
-	return nil
-}
-
-func updateConfig(name string, pipe *Pipe) error {
-	vars := map[string]*string{}
-	if err := toConfig(pipe.This.Data, fmt.Sprintf("PIPE_%s_THIS_", pipe.ID), vars); err != nil {
-		return err
-	}
-	if err := toConfig(pipe.Other.Data, fmt.Sprintf("PIPE_%s_OTHER_", pipe.ID), vars); err != nil {
-		return err
-	}
-	// TODO support multiple connections by aggregating all of the pipes
-	if err := toIncomingIdentity(pipe, vars); err != nil {
-		return err
-	}
-
-	// if the pipe has an oidc adapter set the config on this end
-	log.Infof("Updating config for %s with %+v", name, vars)
-	client.ConfigVarUpdate(context.TODO(), name, vars)
-	return nil
-}
-
-func getResource(name string, url string, discover bool) *Resource {
-	log.Infof("Adding resource %s at %s", name, url)
-	iss := url  // the local factor identity provider uses the app url
-	sub := name // the local factor identity provider uses the app name
-	if discover {
-		// TODO: use heroku run:insade to call `factor issuer` and parse output
-	}
-	callback := func(pipe *Pipe) error {
-		return updateConfig(name, pipe)
-	}
-	uri := URIData{
-		URI: url,
-	}
-	return &Resource{
-		ID:             name,
-		DefaultData:    uri,
-		UpdateCallback: &callback,
-		Pipes:          map[string]*Pipe{},
-		Offers: []*Blueprint{
-			// register an https+oidc offer to be a backing_service for another app
-			NewOffer(
-				"backing_service",
-				[]AdapterType{OIDCAuth},
-				[]*PipeTemplate{
-					NewTemplate(
-						true,
-						OIDCAuth,
-						nil,
-					),
-				},
-				[]*PipeTemplate{
-					NewTemplate(
-						true,
-						ProtoHttps,
-						URIHttpsData{
-							URI: url,
-						},
-					),
-				},
-			),
-		},
-		Needs: []*Blueprint{
-			// register an https+oidc need for a backing_service
-			NewNeed(
-				"backing_service",
-				[]AdapterType{OIDCAuth},
-				[]*PipeTemplate{
-					NewTemplate(
-						false,
-						OIDCAuth,
-						OIDCAuthData{
-							Issuer:   iss,
-							Subject:  sub,
-							Audience: "backing_service", // audience matches the need
-						},
-					),
-				},
-				[]*PipeTemplate{
-					NewTemplate(
-						false,
-						ProtoHttps,
-						nil,
-					),
-				},
-			),
-		},
-	}
-}
-
-func runHeroku() error {
 
 	if t, ok := os.LookupEnv("HEROKU_TEAM"); ok && teamName == "" {
 		teamName = t
@@ -224,13 +66,19 @@ func runHeroku() error {
 	}
 	resources := map[string]*Resource{}
 
+	updater := func(name string, vars map[string]*string) error {
+		_, err := client.ConfigVarUpdate(context.TODO(), name, vars)
+		return err
+	}
+
 	if teamName == "" {
 		apps, err := client.AppList(context.TODO(), nil)
 		if err != nil {
 			log.Fatal(err)
 		}
 		for _, app := range apps {
-			resources[app.Name] = getResource(app.Name, app.WebURL, discover)
+			r := getResourceHeroku(app.Name, app.WebURL, discover, updater)
+			resources[r.ID] = r
 		}
 	} else {
 		apps, err := client.TeamAppListByTeam(context.TODO(), teamName, nil)
@@ -238,32 +86,12 @@ func runHeroku() error {
 			log.Fatal(err)
 		}
 		for _, app := range apps {
-			resources[app.Name] = getResource(app.Name, app.WebURL, discover)
+			r := getResourceHeroku(app.Name, app.WebURL, discover, updater)
+			resources[r.ID] = r
 		}
 	}
 
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINFO)
+	// TODO: watch for changes to app urls and update the other end of the pipe
 
-	go func() {
-		_, prefix := getPortAndPrefix("8002")
-		for {
-			<-sigChan
-			if r, ok := resources["backend"]; ok {
-				r.Mutex.Lock()
-				if p, ok := r.Pipes["frontend"]; ok && p.Other.URI != "" {
-					token, err := generateToken(prefix, p.Other.URI, p.This.URI)
-					if err != nil {
-						log.Errorf("Error generating token: %s", err)
-					}
-					if err := p.This.SetData(URIData{URI: "https://updated.herokuapp.com"}); err != nil {
-						log.Errorf("Error updating URI: %s", err)
-					}
-					updateOther(token, p.Other.URI, p.This.Data)
-				}
-				r.Mutex.Unlock()
-			}
-		}
-	}()
 	return runBrokerServer("8002", resources)
 }

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// localCmd run local server
+var localCmd = &cobra.Command{
+	Use:   "local",
+	Short: "Local broker",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			return fmt.Errorf("invalid command")
+		}
+		return runLocal()
+	},
+}
+
+var path string
+var factor string
+
+func init() {
+	localCmd.Flags().StringVar(&path, "path", ".", "Path to local app")
+	localCmd.Flags().StringVar(&factor, "factor", "factor info", "factor info command")
+	cmd.AddCommand(localCmd)
+}
+func updateEnv(path string, vars map[string]*string) error {
+	envPath := filepath.Join(path, ".env")
+	content := make(map[string]string)
+
+	// Read and parse the existing .env file
+	if data, err := os.Open(envPath); err == nil {
+		defer data.Close()
+		scanner := bufio.NewScanner(data)
+		for scanner.Scan() {
+			line := scanner.Text()
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) == 2 {
+				key := parts[0]
+				value := parts[1]
+				if unquotedValue, err := strconv.Unquote(value); err == nil {
+					content[key] = unquotedValue
+				} else {
+					content[key] = value // Keep the raw value if unquoting fails
+				}
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("error reading .env file: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return err // Return any error except "file does not exist"
+	}
+
+	// Update the content with provided vars
+	for k, v := range vars {
+		if v != nil {
+			content[k] = *v
+		}
+	}
+
+	// Write to a temp file for atomic update
+	tempFile, err := os.CreateTemp(os.TempDir(), "env")
+	if err != nil {
+		return err
+	}
+	tempPath := tempFile.Name()
+	defer os.Remove(tempPath)
+	defer tempFile.Close()
+
+	// Write updated content to the temp file
+	for k, v := range content {
+		quotedValue := strconv.Quote(v)
+		if _, err := tempFile.WriteString(fmt.Sprintf("%s=%s\n", k, quotedValue)); err != nil {
+			return err
+		}
+	}
+
+	if err := tempFile.Sync(); err != nil {
+		return err
+	}
+
+	if err := tempFile.Close(); err != nil {
+		return err
+	}
+
+	// Replace the old .env file with the new one
+	if err := os.Rename(tempPath, envPath); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getResourceLocal(path string, factor string) *Resource {
+	// Run factor meta command and capture output
+	args := strings.Fields(factor)
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Dir = path
+	output, err := cmd.Output()
+	if err != nil {
+		fmt.Printf("Error running factor command: %v\n", err)
+		return nil
+	}
+	name, url, iss, sub := parseMetadata(output)
+
+	updater := func(name string, vars map[string]*string) error {
+		return updateEnv(path, vars)
+	}
+	return getResource(name, url, iss, sub, updater)
+}
+
+func runLocal() error {
+	if p, ok := os.LookupEnv("APP_PATH"); ok && path == "" {
+		path = p
+	}
+	r := getResourceLocal(path, factor)
+	if r == nil {
+		return fmt.Errorf("failed to get resource")
+	}
+	resources := map[string]*Resource{r.ID: r}
+	return runBrokerServer("8003", resources)
+}

--- a/cmd/oidc.go
+++ b/cmd/oidc.go
@@ -64,7 +64,7 @@ func notImplementedHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func openIDConfigHandler(w http.ResponseWriter, r *http.Request) {
-	sc := r.Context().Value("config").(ServerConfig)
+	sc := r.Context().Value(configKey).(ServerConfig)
 	config := map[string]interface{}{
 		"issuer":                                sc.Prefix,
 		"authorization_endpoint":                sc.Prefix + "/authorize",

--- a/cmd/pipe.go
+++ b/cmd/pipe.go
@@ -206,13 +206,6 @@ func (e *End) Equals(other End) bool {
 		bytes.Equal(e.Data, other.Data)
 }
 
-func cleanupSchema(schema *jsonschema.Schema) {
-	if schema == nil {
-		return
-	}
-	schema.AdditionalProperties = nil
-}
-
 const schemaVersion = "https://json-schema.org/draft/2020-12/schema"
 
 func generateSchema(items []any) (*jsonschema.Schema, error) {
@@ -316,11 +309,11 @@ func (e *End) Validate() error {
 	}
 
 	if !result.Valid() {
-		s := fmt.Sprintf("Data does not match schema. see errors :\n")
+		s := "Data does not match schema. see errors :\n"
 		for _, desc := range result.Errors() {
 			s = fmt.Sprintf("%s- %s\n", s, desc)
 		}
-		return fmt.Errorf(s)
+		return fmt.Errorf("%s", s)
 	}
 	return nil
 }
@@ -380,7 +373,7 @@ func (p *Pipe) Merge(o *Pipe) error {
 }
 
 func isJSONEmpty(raw json.RawMessage) bool {
-	if raw == nil || len(raw) == 0 || string(raw) == "null" {
+	if len(raw) == 0 || string(raw) == "null" {
 		return true
 	}
 	return false

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -1,0 +1,191 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+
+func parseMetadata(output []byte) (string, string, string, string) {
+	var name, url, iss, sub string
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		switch key {
+		case "name":
+			name = value
+		case "url":
+			url = value 
+		case "iss":
+			iss = value
+		case "sub":
+			sub = value
+		}
+	}
+	return name, url, iss, sub
+}
+
+type configUpdater func(name string, vars map[string]*string) error
+
+func getResource(name, url, iss, sub string, updater configUpdater) *Resource {
+	log.Infof("Adding resource %s at %s", name, url)
+	callback := func(pipe *Pipe) error {
+		return updateConfig(name, pipe, updater)
+	}
+	uri := URIData{
+		URI: url,
+	}
+	return &Resource{
+		ID:             name,
+		DefaultData:    uri,
+		UpdateCallback: &callback,
+		Pipes:          map[string]*Pipe{},
+		Offers: []*Blueprint{
+			// register an https+oidc offer to be a backing_service for another app
+			NewOffer(
+				"backing_service",
+				[]AdapterType{OIDCAuth},
+				[]*PipeTemplate{
+					NewTemplate(
+						true,
+						OIDCAuth,
+						nil,
+					),
+				},
+				[]*PipeTemplate{
+					NewTemplate(
+						true,
+						ProtoHttps,
+						URIHttpsData{
+							URI: url,
+						},
+					),
+				},
+			),
+		},
+		Needs: []*Blueprint{
+			// register an https+oidc need for a backing_service
+			NewNeed(
+				"backing_service",
+				[]AdapterType{OIDCAuth},
+				[]*PipeTemplate{
+					NewTemplate(
+						false,
+						OIDCAuth,
+						OIDCAuthData{
+							Issuer:   iss,
+							Subject:  sub,
+							Audience: "backing_service", // audience matches the need
+						},
+					),
+				},
+				[]*PipeTemplate{
+					NewTemplate(
+						false,
+						ProtoHttps,
+						nil,
+					),
+				},
+			),
+		},
+	}
+}
+
+
+func toConfig(data json.RawMessage, prefix string, config map[string]*string) error {
+	if isJSONEmpty(data) {
+		return nil
+	}
+	rawMap := map[string]interface{}{}
+	err := json.Unmarshal(data, &rawMap)
+	if err != nil {
+		return fmt.Errorf("error unmarshaling JSON: %w", err)
+	}
+
+	for key, value := range rawMap {
+		strValue := fmt.Sprintf("%v", value)
+		config[strings.ToUpper(fmt.Sprintf("%s%s", prefix, key))] = &strValue
+	}
+	return nil
+}
+
+type IdentityValidator struct {
+	Iss string `json:"iss,omitempty"`
+	Sub string `json:"sub,omitempty"`
+	Aud string `json:"aud,omitempty"`
+}
+
+type IncomingIdentity map[string]IdentityValidator
+
+func toIncomingIdentity(pipe *Pipe, config map[string]*string) error {
+	if isJSONEmpty(pipe.Other.Data) {
+		return nil
+	}
+	rawMap := map[string]interface{}{}
+	err := json.Unmarshal(pipe.Other.Data, &rawMap)
+	if err != nil {
+		return fmt.Errorf("error unmarshaling JSON: %w", err)
+	}
+	if _, ok := rawMap["ISS"]; ok {
+		iss, ok := rawMap["ISS"].(string)
+		if !ok {
+			return fmt.Errorf("field 'ISS' is missing or not a string")
+		}
+		sub, ok := rawMap["SUB"].(string)
+		if !ok {
+			return fmt.Errorf("field 'sub' is missing or not a string")
+		}
+		aud, ok := rawMap["AUD"].(string)
+		if !ok {
+			return fmt.Errorf("field 'aud' is missing or not a string")
+		}
+		incoming := IncomingIdentity{}
+		incoming[pipe.ID] = IdentityValidator{
+			Iss: iss,
+			Sub: sub,
+			Aud: aud,
+		}
+		incomingJson, err := json.Marshal(&incoming)
+		if err != nil {
+			return fmt.Errorf("error marshaling JSON: %w", err)
+		}
+		incomingStr := string(incomingJson)
+		config["INCOMING_IDENTITY"] = &incomingStr
+	}
+	if _, ok := rawMap["URI"]; ok {
+		thisMap := map[string]interface{}{}
+		err := json.Unmarshal(pipe.This.Data, &thisMap)
+		if err != nil {
+			return fmt.Errorf("error unmarshaling JSON: %w", err)
+		}
+		if aud, ok := thisMap["AUD"].(string); ok {
+			// set a config var to create an identity token
+			config[strings.ToUpper(fmt.Sprintf("%s_AUDIENCE", pipe.ID))] = &aud
+		}
+	}
+	return nil
+}
+
+func updateConfig(name string, pipe *Pipe, updater configUpdater) error {
+	vars := map[string]*string{}
+	if err := toConfig(pipe.This.Data, fmt.Sprintf("PIPE_%s_THIS_", pipe.ID), vars); err != nil {
+		return err
+	}
+	if err := toConfig(pipe.Other.Data, fmt.Sprintf("PIPE_%s_OTHER_", pipe.ID), vars); err != nil {
+		return err
+	}
+	// TODO support multiple connections by aggregating all of the pipes
+	if err := toIncomingIdentity(pipe, vars); err != nil {
+		return err
+	}
+
+	log.Infof("Updating config for %s with %+v", name, vars)
+	return updater(name, vars)
+}

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -22,7 +22,9 @@ type ServerConfig struct {
 	Prefix string
 }
 
-const configKey = "config"
+type contextKey string
+
+const configKey contextKey = "config"
 
 // Middleware to add configuration to the context
 func configMiddleware(config ServerConfig, next http.Handler) http.Handler {
@@ -673,7 +675,7 @@ func updatePipe(resource *Resource, pid string, w http.ResponseWriter, r *http.R
 	}
 	resource.Pipes[pid] = &p
 	if !p.This.Equals(this) {
-		sc := r.Context().Value("config").(ServerConfig)
+		sc := r.Context().Value(configKey).(ServerConfig)
 		maybeUpdateOther(&p, &sc)
 	}
 	if resource.UpdateCallback != nil && (!p.This.Equals(this) || !p.Other.Equals(other)) {


### PR DESCRIPTION
Modifies the .env file being used by factor for pipe connections. This splits out some functionality from the heroku broker into a shared file.